### PR TITLE
Add support for upgrade URIs

### DIFF
--- a/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
+++ b/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
@@ -202,6 +202,14 @@ public class MainActivity extends AppCompatActivity {
                 VimeoDeeplink.showPlaylists(MainActivity.this);
             }
         });
+        Button upgradeButton = (Button) findViewById(R.id.activity_main_upgrade_button);
+        upgradeButton.setEnabled(VimeoDeeplink.canHandleUpgradeDeeplink(MainActivity.this));
+        upgradeButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                VimeoDeeplink.showUpgrade(MainActivity.this);
+            }
+        });
         Button uploadButton = (Button) findViewById(R.id.activity_main_upload_button);
         uploadButton.setEnabled(VimeoDeeplink.canHandleUploadDeeplink(MainActivity.this));
         uploadButton.setOnClickListener(new View.OnClickListener() {

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -222,6 +222,13 @@
                     android:layout_height="wrap_content"
                     android:minWidth="@dimen/material_button_min_width"
                     android:text="@string/activity_main_purchases"/>
+
+                <Button
+                    android:id="@+id/activity_main_upgrade_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="@dimen/material_button_min_width"
+                    android:text="@string/activity_main_upgrade"/>
             </TableRow>
         </TableLayout>
 

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="activity_main_notifications">Show Notifications</string>
     <string name="activity_main_notification_settings">Show Push Notification Settings</string>
     <string name="activity_main_playlists">Show Playlists</string>
+    <string name="activity_main_upgrade">Show Upgrade</string>
     <string name="activity_main_upload">Show Upload</string>
     <string name="activity_main_offline">Show Offline</string>
     <string name="activity_main_watchlater">Show Watch Later</string>

--- a/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
+++ b/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
@@ -52,6 +52,7 @@ public final class VimeoDeeplink {
     private static final int VERSION_CODE_DEEP_LINK_ONDEMAND = 470;
     private static final int VERSION_CODE_DEEP_LINK_PLAYLISTS = 74;
     private static final int VERSION_CODE_DEEP_LINK_PURCHASES = 470;
+    private static final int VERSION_CODE_DEEP_LINK_UPGRADE = 2260;
     private static final int VERSION_CODE_DEEP_LINK_UPLOAD = 74;
     private static final int VERSION_CODE_DEEP_LINK_URL = 234;
     private static final int VERSION_CODE_DEEP_LINK_WATCHLATER = 470;
@@ -72,6 +73,7 @@ public final class VimeoDeeplink {
     private static final String OFFLINE = "/offline";
     private static final String PLAYLISTS = "/playlists";
     private static final String PURCHASES = "/purchases";
+    private static final String UPGRADE = "/upgrade";
     private static final String UPLOAD = "/upload";
     private static final String WATCH_LATER = "/watchlater";
 
@@ -498,6 +500,31 @@ public final class VimeoDeeplink {
      */
     public static boolean canHandlePurchaseDeeplink(@NonNull final Context context) {
         return vimeoAppVersion(context) >= VERSION_CODE_DEEP_LINK_PURCHASES ||
+               vimeoAppVersion(context) == VERSION_CODE_DEBUG;
+    }
+
+    /**
+     * Open the Vimeo App to the Upgrade screen
+     *
+     * @param context an Android {@link Context}
+     * @return true if the Vimeo app opens the Upgrade deeplink
+     */
+    public static boolean showUpgrade(@NonNull final Context context) {
+        if (canHandleUpgradeDeeplink(context)) {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(VIMEO_BASE_URI + UPGRADE));
+            return startActivity(context, intent);
+        }
+        return false;
+    }
+
+    /**
+     * Determine if the user's Vimeo app can handle a upgrade deep link
+     *
+     * @param context an Android {@link Context}
+     * @return true if the Vimeo app is installed and it can handle a upgrade deep link
+     */
+    public static boolean canHandleUpgradeDeeplink(@NonNull final Context context) {
+        return vimeoAppVersion(context) >= VERSION_CODE_DEEP_LINK_UPGRADE ||
                vimeoAppVersion(context) == VERSION_CODE_DEBUG;
     }
 


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[VA-2992](https://vimean.atlassian.net/browse/VA-2992)

#### Ticket Summary
Add support for upgrade URIs

#### Implementation Summary
Requests to `/upgrade` URIs now deep link into the In-App purchasing account upgrade screens in the newest version of the Vimeo mobile app.

#### How to Test
- With `v2.26.0` of the Vimeo Android app installed on your device, use the `example` app to test that the IAP flow is started with clicking the "Start Upgrade" button.
- With an older version installed, this button should no-op.
