### PR TITLE
Add new deep link to video manager screen

### DIFF
--- a/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
+++ b/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
@@ -242,6 +242,15 @@ public class MainActivity extends AppCompatActivity {
                 VimeoDeeplink.showPurchases(MainActivity.this);
             }
         });
+
+        Button videoManagerButton = (Button) findViewById(R.id.activity_main_video_manager_button);
+        videoManagerButton.setEnabled(VimeoDeeplink.canHandleVideoManagerDeeplink(MainActivity.this));
+        videoManagerButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                VimeoDeeplink.showVideoManager(MainActivity.this);
+            }
+        });
     }
 
     private String generatedUriPath() {

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -230,6 +230,16 @@
                     android:minWidth="@dimen/material_button_min_width"
                     android:text="@string/activity_main_upgrade"/>
             </TableRow>
+            <TableRow>
+
+                <Button
+                    android:id="@+id/activity_main_video_manager_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="@dimen/material_button_min_width"
+                    android:text="@string/activity_main_video_manager"/>
+
+            </TableRow>
         </TableLayout>
 
     </RelativeLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="activity_main_offline">Show Offline</string>
     <string name="activity_main_watchlater">Show Watch Later</string>
     <string name="activity_main_purchases">Show Purchases</string>
+    <string name="activity_main_video_manager">Show Video Manager</string>
     <string name="activity_main_deeplink_failure">Could not perform the following deep link!
     </string>
 </resources>

--- a/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
+++ b/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
@@ -55,6 +55,7 @@ public final class VimeoDeeplink {
     private static final int VERSION_CODE_DEEP_LINK_UPGRADE = 2260;
     private static final int VERSION_CODE_DEEP_LINK_UPLOAD = 74;
     private static final int VERSION_CODE_DEEP_LINK_URL = 234;
+    private static final int VERSION_CODE_DEEP_LINK_VIDEO_MANAGER = 2340;
     private static final int VERSION_CODE_DEEP_LINK_WATCHLATER = 470;
 
     private static final String VIMEO_BASE_URL_HOST = "vimeo.com";
@@ -75,6 +76,7 @@ public final class VimeoDeeplink {
     private static final String PURCHASES = "/purchases";
     private static final String UPGRADE = "/upgrade";
     private static final String UPLOAD = "/upload";
+    private static final String VIDEO_MANAGER = "/manage/videos";
     private static final String WATCH_LATER = "/watchlater";
 
     public static final String VIMEO_VIDEO_URI_PREFIX = "/videos/";
@@ -550,6 +552,31 @@ public final class VimeoDeeplink {
      */
     public static boolean canHandleUploadDeeplink(@NonNull final Context context) {
         return vimeoAppVersion(context) >= VERSION_CODE_DEEP_LINK_UPLOAD ||
+               vimeoAppVersion(context) == VERSION_CODE_DEBUG;
+    }
+
+    /**
+     * Open the Vimeo App to the Video Manager screen
+     *
+     * @param context an Android {@link Context}
+     * @return true if the Vimeo app opens the Video Manager deeplink
+     */
+    public static boolean showVideoManager(@NonNull final Context context) {
+        if (canHandleVideoManagerDeeplink(context)) {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(VIMEO_BASE_URI + VIDEO_MANAGER));
+            return startActivity(context, intent);
+        }
+        return false;
+    }
+
+    /**
+     * Determine if the user's Vimeo app can handle a video manager deep link
+     *
+     * @param context an Android {@link Context}
+     * @return true if the Vimeo app is installed and it can handle a video manager deep link
+     */
+    public static boolean canHandleVideoManagerDeeplink(@NonNull final Context context) {
+        return vimeoAppVersion(context) >= VERSION_CODE_DEEP_LINK_VIDEO_MANAGER ||
                vimeoAppVersion(context) == VERSION_CODE_DEBUG;
     }
 


### PR DESCRIPTION
#### Ticket
[VA-3210](https://vimean.atlassian.net/browse/VA-3210)

#### Ticket Summary
Add a new deep link target for the Video Manager.

#### Implementation Summary
Adds a new "Show Video Manager" button that follows the same convention as the existing deep link buttons.

#### How to Test
- With a development build of the Vimeo app, clicking "Show Video Manager" should launch the video manager "All Videos" screen.
- Using the Custom URL `https://vimeo.com/manage/videos` should do the same.
