### PR TITLE
VA-3579 Adding support for album details deep link

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.vimeo.android.deeplink.example"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 2
         versionName "1.0.1"
     }
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile project(':vimeo-deeplink')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation project(':vimeo-deeplink')
 }

--- a/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
+++ b/example/src/main/java/com/vimeo/android/deeplink/example/MainActivity.java
@@ -58,6 +58,7 @@ public class MainActivity extends AppCompatActivity {
     private Button mGoButton;
     private EditText mUriEditText;
     private EditText mUserIdForAlbumEditText;
+    private EditText mIdForAlbumEditText;
     private DeepLinkType mDeepLinkType = DeepLinkType.NONE;
 
     private final RadioGroup.OnCheckedChangeListener mCheckedChangeListener =
@@ -292,12 +293,28 @@ public class MainActivity extends AppCompatActivity {
                                 VimeoDeeplink.showAlbums(MainActivity.this, getAlbumsForUserUri());
                             }
                         });
+
+        mIdForAlbumEditText = ((EditText) findViewById(R.id.activity_user_id_album_edit_text));
+
+        configureButton(R.id.activity_main_album_by_id,
+                        VimeoDeeplink.canHandleAlbumsDeeplink(MainActivity.this, getAlbumForId()),
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                VimeoDeeplink.showAlbums(MainActivity.this, getAlbumForId());
+                            }
+                        });
     }
 
     private String getAlbumsForUserUri() {
         return VimeoDeeplink.VIMEO_USER_URI_PREFIX +
                mUserIdForAlbumEditText.getText().toString() +
                VimeoDeeplink.VIMEO_ALBUMS_URI_POSTFIX;
+    }
+
+    private String getAlbumForId() {
+        return VimeoDeeplink.VIMEO_ALBUM_URI_PREFIX + "/" +
+               mIdForAlbumEditText.getText().toString();
     }
 
 

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -213,32 +213,35 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
-                <EditText
-                    android:id="@+id/activity_user_id_albums_edit_text"
-                    android:layout_width="100dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/activity_main_default_user"/>
                 <Button
                     android:id="@+id/activity_main_albums_for_user_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/activity_main_albums_for_user" />
+                <EditText
+                    android:id="@+id/activity_user_id_albums_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/item_separator_margin"
+                    android:text="@string/activity_main_default_user"/>
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
-                <EditText
-                    android:id="@+id/activity_user_id_album_edit_text"
-                    android:layout_width="100dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/activity_main_default_album_id"/>
                 <Button
                     android:id="@+id/activity_main_album_by_id"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/activity_main_album_for_id" />
+                <EditText
+                    android:id="@+id/activity_user_id_album_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/item_separator_margin"
+                    android:text="@string/activity_main_default_album_id"/>
+
             </LinearLayout>
 
         </LinearLayout>

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -225,6 +225,22 @@
                     android:text="@string/activity_main_albums_for_user" />
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <EditText
+                    android:id="@+id/activity_user_id_album_edit_text"
+                    android:layout_width="100dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/activity_main_default_album_id"/>
+                <Button
+                    android:id="@+id/activity_main_album_by_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/activity_main_album_for_id" />
+            </LinearLayout>
+
         </LinearLayout>
     </RelativeLayout>
 </ScrollView>

--- a/example/src/main/res/values/dimens.xml
+++ b/example/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="material_button_min_width">88dp</dimen>
+    <dimen name="item_separator_margin">12dp</dimen>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="activity_main_default_user">ilindy</string>
     <string name="activity_main_albums_for_user">Show Albums For User Id</string>
     <string name="activity_main_albums_manager">Show Albums For Logged In User</string>
-    <string name="activity_main_deeplink_failure">Could not perform the following deep link!
-    </string>
+    <string name="activity_main_deeplink_failure">Could not perform the following deep link!</string>
+    <string name="activity_main_album_for_id">Show Album For Id</string>
+    <string name="activity_main_default_album_id">3576138</string>
 </resources>

--- a/vimeo-deeplink/build.gradle
+++ b/vimeo-deeplink/build.gradle
@@ -26,12 +26,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 3
         versionName libraryVersion
     }
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.1.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
+++ b/vimeo-deeplink/src/main/java/com/vimeo/android/deeplink/VimeoDeeplink.java
@@ -86,6 +86,8 @@ public final class VimeoDeeplink {
     public static final String VIMEO_CHANNEL_URI_PREFIX = "/channels/";
     public static final String VIMEO_ONDEMAND_URI_PREFIX = "/ondemand/";
     public static final String VIMEO_ALBUMS_URI_POSTFIX = "/albums";
+    public static final String VIMEO_ALBUM_URI_PREFIX = "/album";
+    private static final String VIMEO_ALBUM_PATTERN = "^(" + VIMEO_ALBUM_URI_PREFIX + "/)[0-9]+$";
 
 
     /**
@@ -588,9 +590,14 @@ public final class VimeoDeeplink {
      * @param context an Android {@link Context}
      * @return true if the Vimeo app is installed and it can handle an albums deep link
      */
-    public static boolean canHandleAlbumsDeeplink(@NonNull final Context context, String uri) {
+    public static boolean canHandleAlbumsDeeplink(@NonNull final Context context, @NonNull String uri) {
         return (vimeoAppVersion(context) >= VERSION_CODE_DEEP_LINK_ALBUMS ||
-               vimeoAppVersion(context) == VERSION_CODE_DEBUG) && uri.endsWith(VIMEO_ALBUMS_URI_POSTFIX);
+                vimeoAppVersion(context) == VERSION_CODE_DEBUG) &&
+               isValidAlbumUri(uri);
+    }
+
+    public static boolean isValidAlbumUri(@NonNull final String uri) {
+        return uri.endsWith(VIMEO_ALBUMS_URI_POSTFIX) || uri.matches(VIMEO_ALBUM_PATTERN);
     }
 
     public static boolean showAlbums(@NonNull final Context context, String uri) {
@@ -600,7 +607,6 @@ public final class VimeoDeeplink {
         }
         return false;
     }
-
 
 
     /**


### PR DESCRIPTION
# Ticket
[VA-3579](https://vimean.atlassian.net/browse/VA-3579)

## Ticket Summary
Add support for deep linking to the album details page. This should support paths of the format: /album/**album_id** where **album_id** is a strictly numeric sequence of characters.

## Implementation Summary
Adding parsing code to DeepLinkHelper to identify the album pattern and replace /album with /albums since that is the endpoint that the api expects.

## How to Test
Test the following uris:
https://www.vimeo.com/album/farts
expected: app reroutes to browser

https://www.vimeo.com/album/666
expected: goes to album details page with message "There are no videos in this album."

https://www.vimeo.com/album/6661313
expected: goes to album details page with message "Whoops! We are unable to load this album."

https://www.vimeo.com/album/3382569
expected: goes to album details page with a list of videos

https://www.vimeo.com/albums/3382569
expected: app reroutes to browser

Use the deep link helper button "Show Album for Id" with the default id 3382572
expected: goes to album details page with a list of videos

Use the deep link helper button "Show Album for Id" with the id 6661313
expected: goes to album details page with message "Whoops! We are unable to load this album."
